### PR TITLE
bugfix/I32-allow-duplicate-names

### DIFF
--- a/src/allEntities/selectInclusionsStep/ActiveWorkspaceSelect.tsx
+++ b/src/allEntities/selectInclusionsStep/ActiveWorkspaceSelect.tsx
@@ -5,7 +5,7 @@ import {
   activeWorkspaceIdSelector,
   includedSourceWorkspacesSelector,
 } from "~/workspaces/workspacesSelectors";
-import { styled } from "~/components";
+import { styled, WorkspaceSelect } from "~/components";
 import { ReduxState, WorkspaceModel } from "~/typeDefs";
 
 const Base = styled.div(
@@ -37,44 +37,6 @@ const Label = styled.label(
   }),
 );
 
-const Select = styled.select(
-  {
-    appearance: "none",
-    border: "none",
-    borderRadius: "0.375rem",
-    cursor: "pointer",
-    display: "inline-block",
-    fontSize: "1rem",
-    marginTop: "0.5rem",
-    padding: "0.75rem 1rem",
-    width: "100%",
-  },
-  ({ theme }) => ({
-    background: theme.colors.white,
-    boxShadow: theme.elevation.dp2,
-    color: theme.colors.primary,
-  }),
-);
-
-const Arrow = styled.span(
-  {
-    borderBottomColor: "transparent",
-    borderLeftColor: "transparent",
-    borderRightColor: "transparent",
-    borderStyle: "solid",
-    borderWidth: "0.5rem 0.5rem 0",
-    bottom: "1.125rem",
-    height: 0,
-    pointerEvents: "none",
-    position: "absolute",
-    right: "1.5rem",
-    width: 0,
-  },
-  ({ theme }) => ({
-    borderTopColor: theme.colors.midnight,
-  }),
-);
-
 interface ConnectStateProps {
   activeWorkspaceId: string;
   workspaces: WorkspaceModel[];
@@ -87,32 +49,20 @@ interface ConnectDispatchProps {
 type Props = ConnectStateProps & ConnectDispatchProps;
 
 export const ActiveWorkspaceSelectComponent: React.FC<Props> = props => {
-  const handleSelectChange = (
-    event: React.ChangeEvent<HTMLSelectElement>,
-  ): void => {
-    props.onUpdateActiveWorkspaceId(event.target.value);
+  const handleSelectWorkspace = (workspace: WorkspaceModel): void => {
+    props.onUpdateActiveWorkspaceId(workspace.id);
   };
 
   return (
     <Base>
       <Label htmlFor="active-workspace-select">Active Workspace</Label>
-      <Select
+      <WorkspaceSelect
         id="active-workspace-select"
         name="active-workspace-select"
+        workspaces={props.workspaces}
         value={props.activeWorkspaceId}
-        onChange={handleSelectChange}
-      >
-        {props.workspaces.map(workspace => (
-          <option
-            key={workspace.id}
-            label={workspace.name}
-            value={workspace.id}
-          >
-            {workspace.name}
-          </option>
-        ))}
-      </Select>
-      <Arrow />
+        onSelectWorkspace={handleSelectWorkspace}
+      />
     </Base>
   );
 };

--- a/src/app/appRoot/Logo.tsx
+++ b/src/app/appRoot/Logo.tsx
@@ -8,7 +8,7 @@ const Base = styled.svg(
     position: "absolute",
     top: "0.5rem",
     right: "0.5rem",
-    zIndex: 999,
+    zIndex: 10,
 
     circle: {
       strokeWidth: 24,

--- a/src/app/notificationsDisplay/NotificationToast.tsx
+++ b/src/app/notificationsDisplay/NotificationToast.tsx
@@ -33,6 +33,7 @@ const Base = styled.div(
     right: "1rem",
     transition: "top 500ms ease-out",
     width: "20rem",
+    zIndex: 999,
   },
   ({ theme }) => ({
     background: theme.colors.midnight,

--- a/src/components/WorkspaceSelect.tsx
+++ b/src/components/WorkspaceSelect.tsx
@@ -60,7 +60,12 @@ const WorkspaceSelect: React.FC<Props> = ({
 
   return (
     <>
-      <Select value={value} onChange={handleSelectChange} {...props}>
+      <Select
+        data-testid="workspace-select"
+        value={value}
+        onChange={handleSelectChange}
+        {...props}
+      >
         {workspaces.map(workspace => (
           <option
             key={workspace.id}

--- a/src/components/WorkspaceSelect.tsx
+++ b/src/components/WorkspaceSelect.tsx
@@ -1,0 +1,79 @@
+import React from "react";
+import { styled } from "./emotion";
+import { WorkspaceModel } from "~/typeDefs";
+
+const Select = styled.select(
+  {
+    appearance: "none",
+    border: "none",
+    borderRadius: "0.375rem",
+    cursor: "pointer",
+    display: "inline-block",
+    fontSize: "1rem",
+    marginTop: "0.5rem",
+    padding: "0.75rem 1rem",
+    width: "100%",
+  },
+  ({ theme }) => ({
+    background: theme.colors.white,
+    boxShadow: theme.elevation.dp2,
+    color: theme.colors.primary,
+  }),
+);
+
+const Arrow = styled.span(
+  {
+    borderBottomColor: "transparent",
+    borderLeftColor: "transparent",
+    borderRightColor: "transparent",
+    borderStyle: "solid",
+    borderWidth: "0.5rem 0.5rem 0",
+    bottom: "1.125rem",
+    height: 0,
+    pointerEvents: "none",
+    position: "absolute",
+    right: "1.5rem",
+    width: 0,
+  },
+  ({ theme }) => ({
+    borderTopColor: theme.colors.midnight,
+  }),
+);
+
+interface Props extends React.HTMLProps<HTMLSelectElement> {
+  workspaces: WorkspaceModel[];
+  onSelectWorkspace: (workspace: WorkspaceModel) => void;
+}
+
+const WorkspaceSelect: React.FC<Props> = ({
+  workspaces,
+  value,
+  onSelectWorkspace,
+  ...props
+}) => {
+  const handleSelectChange = (
+    event: React.ChangeEvent<HTMLSelectElement>,
+  ): void => {
+    const workspace = workspaces.find(({ id }) => id === event.target.value);
+    onSelectWorkspace(workspace as WorkspaceModel);
+  };
+
+  return (
+    <>
+      <Select value={value} onChange={handleSelectChange} {...props}>
+        {workspaces.map(workspace => (
+          <option
+            key={workspace.id}
+            label={workspace.name}
+            value={workspace.id}
+          >
+            {workspace.name}
+          </option>
+        ))}
+      </Select>
+      <Arrow />
+    </>
+  );
+};
+
+export default WorkspaceSelect;

--- a/src/components/__tests__/WorkspaceSelect.test.tsx
+++ b/src/components/__tests__/WorkspaceSelect.test.tsx
@@ -1,0 +1,38 @@
+import React from "react";
+import { render, RenderResult, fireEvent } from "~/jestHelpers";
+import state from "~/redux/__fixtures__/state";
+import WorkspaceSelect from "../WorkspaceSelect";
+
+const setup = (
+  propOverrides: any = {},
+): { props: any; wrapper: RenderResult } => {
+  const props = {
+    workspaces: Object.values(state.workspaces.source),
+    onSelectWorkspace: jest.fn(),
+    ...propOverrides,
+  };
+
+  const wrapper = render(<WorkspaceSelect {...props} />);
+
+  return { props, wrapper };
+};
+
+describe("the <WorkspaceSelect> component", () => {
+  test("matches its snapshot with valid props", () => {
+    const { wrapper } = setup();
+
+    expect(wrapper.container.firstElementChild).toBeInTheDocument();
+  });
+
+  test("fires props.onSelectWorkspace when a workspace is selected", () => {
+    const { wrapper, props } = setup();
+    fireEvent.change(wrapper.getByTestId("workspace-select"), {
+      target: {
+        value: "1001",
+      },
+    });
+    const matchingWorkspace = state.workspaces.source["1001"];
+
+    expect(props.onSelectWorkspace).toHaveBeenCalledWith(matchingWorkspace);
+  });
+});

--- a/src/components/index.tsx
+++ b/src/components/index.tsx
@@ -25,3 +25,4 @@ export { default as NoRecordsFound } from "./NoRecordsFound";
 export { default as Note } from "./Note";
 export { default as Toggle } from "./Toggle";
 export { default as VisuallyHidden } from "./VisuallyHidden";
+export { default as WorkspaceSelect } from "./WorkspaceSelect";

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -10,8 +10,10 @@ export const STORAGE_KEY = "transfermytime";
 
 export const CLOCKIFY_API_URL = "https://api.clockify.me/api";
 export const CLOCKIFY_API_PAGE_SIZE = 100;
-// Delay time for requests to ensure rate limits are not exceeded:
-export const CLOCKIFY_API_DELAY = IS_USING_LOCAL_API ? 0 : 1_000 / 4;
+// Delay time for requests to ensure rate limits are not exceeded.
+// The documentation limits requests to 10 per second, but we're using a higher
+// delay to accommodate for differences between the working API and stable API:
+export const CLOCKIFY_API_DELAY = IS_USING_LOCAL_API ? 0 : 1_000 / 8;
 
 export const TOGGL_API_URL = "https://www.toggl.com/api/v8";
 export const TOGGL_REPORTS_URL = "https://toggl.com/reports/api/v2";

--- a/src/redux/reduxUtils/linkEntitiesByIdByMapping.ts
+++ b/src/redux/reduxUtils/linkEntitiesByIdByMapping.ts
@@ -179,16 +179,21 @@ function doProjectsMatch(
   sourceEntry: TimeEntryModel,
   targetEntry: TimeEntryModel,
 ): boolean {
-  if (sourceEntry.projectId === null) {
+  if (sourceEntry.projectId === null && targetEntry.projectId === null) {
+    return true;
+  }
+
+  if (sourceEntry.projectId !== null && targetEntry.projectId === null) {
     return false;
   }
 
-  const sourceProject = sourceProjectsById[sourceEntry.projectId] ?? null;
+  if (sourceEntry.projectId === null && targetEntry.projectId !== null) {
+    return false;
+  }
+
+  const validProjectId = sourceEntry.projectId ?? "";
+  const sourceProject = sourceProjectsById[validProjectId] ?? null;
   if (sourceProject === null) {
-    return false;
-  }
-
-  if (targetEntry.projectId === null) {
     return false;
   }
 

--- a/src/redux/reduxUtils/linkEntitiesByIdByMapping.ts
+++ b/src/redux/reduxUtils/linkEntitiesByIdByMapping.ts
@@ -2,6 +2,7 @@ import { SagaIterator } from "@redux-saga/types";
 import differenceInMinutes from "date-fns/differenceInMinutes";
 import * as R from "ramda";
 import { call, select } from "redux-saga/effects";
+import { workspaceIdToLinkedIdSelector } from "~/workspaces/workspacesSelectors";
 import {
   BaseEntityModel,
   EntityGroup,
@@ -11,6 +12,11 @@ import {
   TimeEntriesByIdModel,
   TimeEntryModel,
 } from "~/typeDefs";
+
+enum LinkFromType {
+  Source,
+  Target,
+}
 
 /**
  * Sets the `linkedId` and `isIncluded` field of the source and target records
@@ -60,11 +66,24 @@ export function* linkEntitiesByIdByMapping<TEntity>(
 
   // Users may have the same name, but they should never have the same email:
   const field = memberOf === EntityGroup.Users ? "email" : "name";
+  const workspaceIdToLinkedId = yield select(workspaceIdToLinkedIdSelector);
 
-  return {
-    source: linkForMappingByField(field, targetRecords, sourceRecords),
-    target: linkForMappingByField(field, sourceRecords, targetRecords),
-  };
+  const source = linkForMappingByField(
+    field,
+    workspaceIdToLinkedId,
+    LinkFromType.Target,
+    targetRecords,
+    sourceRecords,
+  );
+  const target = linkForMappingByField(
+    field,
+    workspaceIdToLinkedId,
+    LinkFromType.Source,
+    sourceRecords,
+    targetRecords,
+  );
+
+  return { source, target };
 }
 
 /**
@@ -75,36 +94,55 @@ export function* linkEntitiesByIdByMapping<TEntity>(
  */
 function linkForMappingByField<TEntity>(
   field: string,
+  workspaceIdToLinkedId: Record<string, string>,
+  linkFromType: LinkFromType,
   linkFromRecords: TEntity[],
   recordsToUpdate: TEntity[],
 ): Record<string, TEntity> {
   type LinkableRecord = TEntity & {
     id: string;
+    workspaceId: string;
     memberOf: EntityGroup;
   };
 
-  const linkFromEntitiesByField = R.indexBy<LinkableRecord>(
-    R.prop(field),
-    linkFromRecords as LinkableRecord[],
-  );
-
   const linkedRecordsById = {};
+
   for (const recordToUpdate of recordsToUpdate as LinkableRecord[]) {
-    const linkedId = R.pathOr(
-      null,
-      [recordToUpdate[field], "id"],
-      linkFromEntitiesByField,
+    const matchingLinkedRecord = (linkFromRecords as LinkableRecord[]).find(
+      linkFromRecord => {
+        // For workspaces, we only want to check if the names match (since
+        // workspaces are the top-level entity and it's impossible to have 2
+        // workspaces with the same name):
+        const fieldsMatch = recordToUpdate[field] === linkFromRecord[field];
+        if (recordToUpdate.memberOf === EntityGroup.Workspaces) {
+          return fieldsMatch;
+        }
+
+        // For all other entities, we need to ensure the fields match _and_
+        // the workspaces are linked. If we don't perform this check, the
+        // transfer process will fail if the user has multiple workspaces
+        // that have the same named entity in each one. For example, if a user
+        // has Workspace A and Workspace B, and both of them have a client
+        // named "Client", the client ID of Workspace A may be associated
+        // with a project in Workspace B and the API will return a 400.
+        // See this issue: https://github.com/mikerourke/transfermyti.me/issues/32
+        const linkedWorkspaceId =
+          workspaceIdToLinkedId[linkFromRecord.workspaceId];
+        return fieldsMatch && recordToUpdate.workspaceId === linkedWorkspaceId;
+      },
     );
+
+    const linkedId = R.isNil(matchingLinkedRecord)
+      ? null
+      : matchingLinkedRecord.id;
+    const isIncluded = R.isNil(linkedId)
+      ? recordToUpdate.memberOf !== EntityGroup.Workspaces
+      : false;
 
     linkedRecordsById[recordToUpdate.id] = {
       ...recordToUpdate,
       linkedId,
-      isIncluded: R.or(
-        // By default, we want all the workspaces to be included (even if they
-        // already exist on the target):
-        recordToUpdate.memberOf === EntityGroup.Workspaces,
-        R.isNil(linkedId),
-      ),
+      isIncluded,
     };
   }
 

--- a/src/timeEntries/timeEntriesInclusionsPanel/TimeEntryComparisonDisclaimer.tsx
+++ b/src/timeEntries/timeEntriesInclusionsPanel/TimeEntryComparisonDisclaimer.tsx
@@ -33,7 +33,8 @@ const TimeEntryComparisonDisclaimer: React.FC = () => (
         Do the <strong>description</strong> fields <i>exactly</i> match?
       </li>
       <li>
-        Is the source and target entry in the same <strong>project</strong>?
+        Is the source and target entry in the same <strong>project</strong> (or
+        are neither of them associated with a project)?
       </li>
       <li>
         Is there less than 1 minute of difference between the

--- a/src/workspaces/__tests__/workspacesReducer.test.ts
+++ b/src/workspaces/__tests__/workspacesReducer.test.ts
@@ -233,10 +233,26 @@ describe("within workspacesReducer", () => {
     });
 
     test(`flips the source "isIncluded" value only if not linked`, () => {
+      const TEST_CLOCKIFY_WORKSPACE = {
+        id: "clock-workspace-01",
+        name: "Test Workspace",
+        userIds: [],
+        isAdmin: true,
+        workspaceId: "clock-workspace-01",
+        entryCount: 0,
+        linkedId: TEST_WORKSPACE_ID,
+        isIncluded: true,
+        memberOf: "workspaces",
+      } as any;
+
       const updatedState = {
         ...TEST_WORKSPACES_STATE,
-        target: {
+        source: {
+          ...TEST_WORKSPACES_STATE.source,
           [TEST_ALT_WORKSPACE.id]: TEST_ALT_WORKSPACE,
+        },
+        target: {
+          [TEST_CLOCKIFY_WORKSPACE.id]: TEST_CLOCKIFY_WORKSPACE,
         },
       };
 
@@ -245,7 +261,7 @@ describe("within workspacesReducer", () => {
         workspacesActions.flipIsWorkspaceIncluded(TEST_ALT_WORKSPACE),
       );
 
-      expect(result.source[TEST_ALT_WORKSPACE.id].isIncluded).toBe(true);
+      expect(result.source[TEST_WORKSPACE_ID].isIncluded).toBe(true);
     });
   });
 

--- a/src/workspaces/__tests__/workspacesReducer.test.ts
+++ b/src/workspaces/__tests__/workspacesReducer.test.ts
@@ -118,6 +118,87 @@ describe("within workspacesReducer", () => {
     });
   });
 
+  describe("the workspacesActions.updateWorkspaceLinking action", () => {
+    const TEST_TARGET_ID = "clockify-workspace-01";
+
+    test(`updates the "isIncluded" and "linkedId" values when payload.targetId is not null`, () => {
+      const updatedState = {
+        ...TEST_WORKSPACES_STATE,
+        source: {
+          [TEST_WORKSPACE_ID]: {
+            ...TEST_WORKSPACES_STATE.source[TEST_WORKSPACE_ID],
+            isIncluded: false,
+            linkedId: null,
+          },
+        },
+        target: {
+          [TEST_TARGET_ID]: {
+            ...TEST_WORKSPACES_STATE.target[TEST_TARGET_ID],
+            isIncluded: false,
+            linkedId: null,
+          },
+        },
+      };
+
+      const result = workspacesReducer(
+        updatedState,
+        workspacesActions.updateWorkspaceLinking({
+          sourceId: TEST_WORKSPACE_ID,
+          targetId: TEST_TARGET_ID,
+        }),
+      );
+
+      expect(result.source[TEST_WORKSPACE_ID].isIncluded).toBe(true);
+      expect(result.source[TEST_WORKSPACE_ID].linkedId).toBe(TEST_TARGET_ID);
+      expect(result.target[TEST_TARGET_ID].isIncluded).toBe(true);
+      expect(result.target[TEST_TARGET_ID].linkedId).toBe(TEST_WORKSPACE_ID);
+    });
+
+    test(`updates the "isIncluded" and "linkedId" values when payload.targetId is null`, () => {
+      const updatedState = {
+        ...TEST_WORKSPACES_STATE,
+        source: {
+          [TEST_WORKSPACE_ID]: {
+            ...TEST_WORKSPACES_STATE.source[TEST_WORKSPACE_ID],
+            isIncluded: true,
+            linkedId: TEST_TARGET_ID,
+          },
+        },
+        target: {
+          [TEST_TARGET_ID]: {
+            ...TEST_WORKSPACES_STATE.target[TEST_TARGET_ID],
+            isIncluded: true,
+            linkedId: TEST_WORKSPACE_ID,
+          },
+          "clock-workspace-02": {
+            id: "clock-workspace-02",
+            name: "Test Workspace",
+            userIds: [],
+            isAdmin: true,
+            workspaceId: "clock-workspace-02",
+            entryCount: 0,
+            linkedId: null,
+            isIncluded: false,
+            memberOf: "workspaces",
+          },
+        },
+      };
+
+      const result = workspacesReducer(
+        updatedState,
+        workspacesActions.updateWorkspaceLinking({
+          sourceId: TEST_WORKSPACE_ID,
+          targetId: null,
+        }),
+      );
+
+      expect(result.source[TEST_WORKSPACE_ID].isIncluded).toBe(false);
+      expect(result.source[TEST_WORKSPACE_ID].linkedId).toBeNull();
+      expect(result.target[TEST_TARGET_ID].isIncluded).toBe(false);
+      expect(result.target[TEST_TARGET_ID].linkedId).toBeNull();
+    });
+  });
+
   describe("the flipIsWorkspaceIncluded action", () => {
     const TARGET_ID = "clock-workspace-01";
 

--- a/src/workspaces/__tests__/workspacesSelectors.test.ts
+++ b/src/workspaces/__tests__/workspacesSelectors.test.ts
@@ -150,6 +150,42 @@ describe("within workspacesSelectors", () => {
     });
   });
 
+  describe("the hasDuplicateTargetWorkspacesSelector", () => {
+    test("returns false if not duplicate linkedIds are present", () => {
+      const result = workspacesSelectors.hasDuplicateTargetWorkspacesSelector(
+        TEST_STATE,
+      );
+
+      expect(result).toBe(false);
+    });
+
+    test("returns true if duplicate linkedIds are present", () => {
+      const updatedState = {
+        ...TEST_STATE,
+        workspaces: {
+          ...TEST_STATE.workspaces,
+          source: {
+            ...TEST_STATE.workspaces.source,
+            "1001": {
+              ...TEST_STATE.workspaces.source["1001"],
+              linkedId: "clock-workspace-01",
+            },
+            "1002": {
+              ...TEST_STATE.workspaces.source["1002"],
+              linkedId: "clock-workspace-01",
+            },
+          },
+        },
+      };
+
+      const result = workspacesSelectors.hasDuplicateTargetWorkspacesSelector(
+        updatedState,
+      );
+
+      expect(result).toBe(true);
+    });
+  });
+
   test("the includedWorkspaceIdsByMappingSelector ignores workspaces that aren't included", () => {
     const updatedState = {
       ...TEST_STATE,

--- a/src/workspaces/sagas/clockifyWorkspacesSagas.ts
+++ b/src/workspaces/sagas/clockifyWorkspacesSagas.ts
@@ -110,7 +110,7 @@ function transformFromResponse(
     workspaceId: workspace.id,
     entryCount: 0,
     linkedId: null,
-    isIncluded: true,
+    isIncluded: false,
     memberOf: EntityGroup.Workspaces,
   };
 }

--- a/src/workspaces/sagas/togglWorkspacesSagas.ts
+++ b/src/workspaces/sagas/togglWorkspacesSagas.ts
@@ -42,7 +42,7 @@ function transformFromResponse(
     workspaceId: workspace.id.toString(),
     entryCount: 0,
     linkedId: null,
-    isIncluded: true,
+    isIncluded: false,
     memberOf: EntityGroup.Workspaces,
   };
 }

--- a/src/workspaces/selectSourceWorkspacesStep/DuplicateTargetsModal.tsx
+++ b/src/workspaces/selectSourceWorkspacesStep/DuplicateTargetsModal.tsx
@@ -1,0 +1,20 @@
+import React from "react";
+import { ModalDialog } from "~/components";
+
+interface Props {
+  isOpen: boolean;
+  onClose: VoidFunction;
+}
+
+const DuplicateTargetsModal: React.FC<Props> = props => (
+  <ModalDialog isOpen={props.isOpen} title="Error" onClose={props.onClose}>
+    <p>
+      You cannot select the same target workspace for two different source
+      workspaces. Please either select a different target workspace or
+      <strong> None</strong> from the <strong>Target Workspace </strong>
+      dropdown.
+    </p>
+  </ModalDialog>
+);
+
+export default DuplicateTargetsModal;

--- a/src/workspaces/selectSourceWorkspacesStep/SelectSourceWorkspacesStep.tsx
+++ b/src/workspaces/selectSourceWorkspacesStep/SelectSourceWorkspacesStep.tsx
@@ -144,6 +144,14 @@ export const SelectSourceWorkspacesStepComponent: React.FC<Props> = props => {
           deletion/transfer and press the <strong>Next</strong> button to move
           on to the inclusions selection step.
         </p>
+        {props.toolAction === ToolAction.Transfer && (
+          <p>
+            Once a workspace is toggled, you must select a target workspace for
+            transfer (if workspaces exist on the target tool) from the
+            <strong> Target Workspace</strong> dropdown. If you&apos;re
+            transferring to Toggl, you must create the workspaces first.
+          </p>
+        )}
         <p>
           If you decide you want to include additional workspaces, you&apos;ll
           need to come back to this page and select them, otherwise the

--- a/src/workspaces/selectSourceWorkspacesStep/SourceWorkspaceCard.tsx
+++ b/src/workspaces/selectSourceWorkspacesStep/SourceWorkspaceCard.tsx
@@ -1,8 +1,10 @@
+import * as R from "ramda";
 import React from "react";
-import { Card, styled, Toggle } from "~/components";
-import { WorkspaceModel } from "~/typeDefs";
+import { Card, styled, Toggle, WorkspaceSelect } from "~/components";
+import { ToolAction, WorkspaceModel } from "~/typeDefs";
 
 const WorkspaceToggle = styled(Toggle)({}, ({ theme }) => ({
+  marginBottom: "0.5rem",
   marginTop: "0.5rem",
   background: theme.colors.secondary,
 
@@ -11,31 +13,79 @@ const WorkspaceToggle = styled(Toggle)({}, ({ theme }) => ({
   },
 }));
 
+const SectionHeader = styled.h3({
+  marginBottom: "0.25rem",
+  marginTop: "0.5rem",
+});
+
 interface Props {
-  workspace: WorkspaceModel;
-  onToggleIncluded: (workspace: WorkspaceModel) => void;
+  sourceWorkspace: WorkspaceModel;
+  targetWorkspaces: WorkspaceModel[];
+  toolAction: ToolAction;
+  onSelectTarget: (
+    sourceWorkspace: WorkspaceModel,
+    targetWorkspace: WorkspaceModel,
+  ) => void;
+  onToggleIncluded: (sourceWorkspace: WorkspaceModel) => void;
 }
 
 const SourceWorkspaceCard: React.FC<Props> = ({
-  workspace,
-  onToggleIncluded,
+  sourceWorkspace,
+  targetWorkspaces,
   ...props
 }) => {
-  const titleId = `include-toggle-${workspace.id}`;
+  const titleId = `include-toggle-${sourceWorkspace.id}`;
+  const targetWorkspace = targetWorkspaces.find(
+    workspace => workspace.id === sourceWorkspace.linkedId,
+  );
+  const targetSelectValue = R.isNil(targetWorkspace)
+    ? undefined
+    : targetWorkspace.id;
 
   const handleToggleIncludeWorkspace = (): void => {
-    onToggleIncluded(workspace);
+    props.onToggleIncluded(sourceWorkspace);
   };
 
+  const handleSelectWorkspace = (workspace: WorkspaceModel): void => {
+    props.onSelectTarget(sourceWorkspace, workspace);
+  };
+
+  const workspacesForSelect = [
+    { id: "", name: "None (Create New)" } as WorkspaceModel,
+    ...targetWorkspaces,
+  ];
+
+  const actionTitle =
+    props.toolAction === ToolAction.Delete
+      ? "Include in Deletion?"
+      : "Include in Transfer?";
+
   return (
-    <Card title={workspace.name} {...props}>
-      <div id={titleId}>Include this workspace?</div>
+    <Card title={sourceWorkspace.name} css={{ h2: { margin: 0 } }}>
+      <hr css={{ width: "100%" }} />
+      <SectionHeader id={titleId}>{actionTitle}</SectionHeader>
       <WorkspaceToggle
-        aria-label="Include this workspace"
+        aria-label={actionTitle}
         aria-labelledby={titleId}
-        isToggled={workspace.isIncluded}
+        isToggled={sourceWorkspace.isIncluded}
         onToggle={handleToggleIncludeWorkspace}
       />
+      {sourceWorkspace.isIncluded && targetWorkspaces.length !== 0 && (
+        <>
+          <SectionHeader>Target Workspace</SectionHeader>
+          <div css={{ marginBottom: "0.5rem", position: "relative" }}>
+            <WorkspaceSelect
+              css={theme => ({
+                background: theme.colors.secondary,
+                fontSize: "1.125rem",
+              })}
+              workspaces={workspacesForSelect}
+              value={targetSelectValue}
+              onSelectWorkspace={handleSelectWorkspace}
+            />
+          </div>
+        </>
+      )}
     </Card>
   );
 };

--- a/src/workspaces/selectSourceWorkspacesStep/SourceWorkspaceCard.tsx
+++ b/src/workspaces/selectSourceWorkspacesStep/SourceWorkspaceCard.tsx
@@ -36,29 +36,41 @@ const SourceWorkspaceCard: React.FC<Props> = ({
 }) => {
   const titleId = `include-toggle-${sourceWorkspace.id}`;
   const targetWorkspace = targetWorkspaces.find(
-    workspace => workspace.id === sourceWorkspace.linkedId,
+    ({ id }) => id === sourceWorkspace.linkedId,
   );
   const targetSelectValue = R.isNil(targetWorkspace)
     ? undefined
     : targetWorkspace.id;
 
-  const handleToggleIncludeWorkspace = (): void => {
-    props.onToggleIncluded(sourceWorkspace);
-  };
+  const workspacesForSelect = [...targetWorkspaces];
+  const matchingNameWorkspace = targetWorkspaces.find(
+    ({ name }) => name.toLowerCase() === sourceWorkspace.name.toLowerCase(),
+  );
 
-  const handleSelectWorkspace = (workspace: WorkspaceModel): void => {
-    props.onSelectTarget(sourceWorkspace, workspace);
-  };
-
-  const workspacesForSelect = [
-    { id: "", name: "None (Create New)" } as WorkspaceModel,
-    ...targetWorkspaces,
-  ];
+  // Don't allow the user to pick the "Create New" option if a workspace with
+  // a matching name exists on the target:
+  if (!matchingNameWorkspace) {
+    workspacesForSelect.unshift({
+      id: "",
+      name: "None (Create New)",
+    } as WorkspaceModel);
+  }
 
   const actionTitle =
     props.toolAction === ToolAction.Delete
       ? "Include in Deletion?"
       : "Include in Transfer?";
+
+  const handleToggleIncludeWorkspace = (): void => {
+    props.onToggleIncluded(sourceWorkspace);
+    if (matchingNameWorkspace && !sourceWorkspace.isIncluded) {
+      props.onSelectTarget(sourceWorkspace, matchingNameWorkspace);
+    }
+  };
+
+  const handleSelectWorkspace = (workspace: WorkspaceModel): void => {
+    props.onSelectTarget(sourceWorkspace, workspace);
+  };
 
   return (
     <Card title={sourceWorkspace.name} css={{ h2: { margin: 0 } }}>

--- a/src/workspaces/workspacesActions.ts
+++ b/src/workspaces/workspacesActions.ts
@@ -17,6 +17,10 @@ export const updateActiveWorkspaceId = createAction(
   "@workspaces/UPDATE_ACTIVE_WORKSPACE_ID",
 )<string>();
 
+export const updateWorkspaceLinking = createAction(
+  "@workspaces/UPDATE_WORKSPACE_LINKING",
+)<{ sourceId: string; targetId: string | null }>();
+
 export const appendUserIdsToWorkspace = createAction(
   "@workspaces/APPEND_USER_IDS_TO_WORKSPACE",
 )<{ mapping: Mapping; workspaceId: string; userIds: string[] }>();

--- a/src/workspaces/workspacesReducer.ts
+++ b/src/workspaces/workspacesReducer.ts
@@ -78,7 +78,11 @@ export const workspacesReducer = createReducer<
 
       const source = {
         ...state.source,
-        [sourceId]: { ...state.source[sourceId], linkedId: targetId },
+        [sourceId]: {
+          ...state.source[sourceId],
+          isIncluded: targetId !== null,
+          linkedId: targetId,
+        },
       };
 
       const target = Object.entries({ ...state.target }).reduce(
@@ -94,6 +98,7 @@ export const workspacesReducer = createReducer<
               },
             };
           }
+
           return { ...acc, [workspaceId]: workspace };
         },
         {},

--- a/src/workspaces/workspacesReducer.ts
+++ b/src/workspaces/workspacesReducer.ts
@@ -72,6 +72,37 @@ export const workspacesReducer = createReducer<
     }),
   )
   .handleAction(
+    workspacesActions.updateWorkspaceLinking,
+    (state, { payload }) => {
+      const { sourceId, targetId } = payload;
+
+      const source = {
+        ...state.source,
+        [sourceId]: { ...state.source[sourceId], linkedId: targetId },
+      };
+
+      const target = Object.entries({ ...state.target }).reduce(
+        (acc, [workspaceId, workspace]) => {
+          const idMatchesTarget = workspaceId === targetId;
+          if (workspace.linkedId === sourceId || idMatchesTarget) {
+            return {
+              ...acc,
+              [workspaceId]: {
+                ...workspace,
+                isIncluded: idMatchesTarget,
+                linkedId: idMatchesTarget ? sourceId : null,
+              },
+            };
+          }
+          return { ...acc, [workspaceId]: workspace };
+        },
+        {},
+      );
+
+      return { ...state, source, target };
+    },
+  )
+  .handleAction(
     workspacesActions.resetContentsForMapping,
     (state, { payload }) => ({
       ...state,

--- a/src/workspaces/workspacesSelectors.ts
+++ b/src/workspaces/workspacesSelectors.ts
@@ -21,7 +21,10 @@ export const sourceWorkspacesByIdSelector = createSelector(
 
 export const sourceWorkspacesSelector = createSelector(
   sourceWorkspacesByIdSelector,
-  (workspacesById): WorkspaceModel[] => Object.values(workspacesById),
+  (workspacesById): WorkspaceModel[] => {
+    const workspaces = Object.values(workspacesById);
+    return R.sortBy(R.compose(R.toLower, R.prop("name")), workspaces);
+  },
 );
 
 export const firstIncludedWorkspaceIdSelector = createSelector(
@@ -67,15 +70,39 @@ export const workspaceIdToLinkedIdSelector = createSelector(
     selectIdToLinkedId(sourceWorkspacesById),
 );
 
-const targetWorkspacesSelector = createSelector(
+export const targetWorkspacesSelector = createSelector(
   targetWorkspacesByIdSelector,
-  (workspacesById): WorkspaceModel[] => Object.values(workspacesById),
+  (workspacesById): WorkspaceModel[] => {
+    const workspaces = Object.values(workspacesById);
+    return R.sortBy(R.compose(R.toLower, R.prop("name")), workspaces);
+  },
 );
 
 export const missingTargetWorkspacesSelector = createSelector(
   includedSourceWorkspacesSelector,
   (includedSourceWorkspaces): WorkspaceModel[] =>
     includedSourceWorkspaces.filter(({ linkedId }) => linkedId === null),
+);
+
+export const hasDuplicateTargetWorkspacesSelector = createSelector(
+  includedSourceWorkspacesSelector,
+  (includedSourceWorkspaces): boolean => {
+    const countByLinkedId: Record<string, number> = {};
+
+    for (const { linkedId } of includedSourceWorkspaces) {
+      if (!linkedId) {
+        continue;
+      }
+
+      if (linkedId in countByLinkedId) {
+        countByLinkedId[linkedId] += 1;
+      } else {
+        countByLinkedId[linkedId] = 1;
+      }
+    }
+
+    return Object.values(countByLinkedId).some(count => count > 1);
+  },
 );
 
 const limitIdsToIncluded = (workspaces: WorkspaceModel[]): string[] =>


### PR DESCRIPTION
## Description
Fixes issue with being unable to transfer duplicate client, project, or tag names from separate workspaces.  Closes #32.

## Overview of Changes
- Add check to entity linking to ensure workspace IDs match
- Add dropdown to source workspace selection card to map source to target workspace
- Change Clockify API delay

## Issues
- Toggl private projects stop import process (#32)