### PR TITLE
update Toggl URLs

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -15,7 +15,7 @@ export const CLOCKIFY_API_PAGE_SIZE = 100;
 // delay to accommodate for differences between the working API and stable API:
 export const CLOCKIFY_API_DELAY = IS_USING_LOCAL_API ? 0 : 1_000 / 8;
 
-export const TOGGL_API_URL = "https://www.toggl.com/api/v8";
-export const TOGGL_REPORTS_URL = "https://toggl.com/reports/api/v2";
+export const TOGGL_API_URL = "https://api.track.toggl.com/api/v8";
+export const TOGGL_REPORTS_URL = "https://api.track.toggl.com/reports/api/v2";
 // Delay time for requests to ensure rate limits are not exceeded:
 export const TOGGL_API_DELAY = IS_USING_LOCAL_API ? 0 : 1_000 / 4;


### PR DESCRIPTION
per Toggl API docs:
> Using the API from toggl.com or www.toggl.com will be dropped at The End of June 2021. Switch to api.track.toggl.com
https://github.com/toggl/toggl_api_docs