### PR TITLE
feat/skip-tasks-for-free-toggle-accounts

### DIFF
--- a/src/api/apiRequests.ts
+++ b/src/api/apiRequests.ts
@@ -303,9 +303,14 @@ export class ApiError extends Error {
   public toJson(): Record<string, any> {
     const headers: Record<string, string> = {};
 
-    // @ts-ignore
-    for (const [name, value] of this.#response.headers) {
-      headers[name] = value;
+    // We don't want this to blow up the app if it fails:
+    try {
+      // @ts-ignore
+      for (const [name, value] of this.#response.headers) {
+        headers[name] = value;
+      }
+    } catch {
+      // Do nothing.
     }
 
     return {

--- a/src/redux/tasks/sagas/togglTasksSagas.ts
+++ b/src/redux/tasks/sagas/togglTasksSagas.ts
@@ -71,18 +71,16 @@ export function* fetchTogglTasksSaga(): SagaIterator<Task[]> {
 
   const togglProjectsTable = allProjectsTable[ToolName.Toggl];
 
-  // prettier-ignore
-  const tableEntries = Object.entries(togglProjectsTable) as [string, Project[]][];
-
-  const allFreeWorkspaceIds = yield select(allFreeWorkspaceIdsSelector);
-
   const allTasks: Task[] = [];
 
   const apiDelay = getApiDelayForTool(ToolName.Toggl);
 
+  const allFreeWorkspaceIds = yield select(allFreeWorkspaceIdsSelector);
+
   const freeWorkspaceIds = new Set<string>();
 
-  for (const [workspaceId, projects] of tableEntries) {
+  for (const entry of Object.entries(togglProjectsTable)) {
+    const [workspaceId, projects] = entry as [string, Project[]];
     // Toggl tasks can't be fetched for paid workspaces. Rather than make a
     // bunch of requests that return 402, we skip them. We add it to a set
     // rather than just continue out of the loop, so we can catch fetch errors

--- a/src/redux/workspaces/workspacesSelectors.ts
+++ b/src/redux/workspaces/workspacesSelectors.ts
@@ -74,6 +74,20 @@ export const targetWorkspacesSelector = createSelector(
   },
 );
 
+export const allWorkspacesByIdSelector = createSelector(
+  sourceWorkspacesSelector,
+  targetWorkspacesSelector,
+  (sourceWorkspaces, targetWorkspaces): Record<string, Workspace> => {
+    const allWorkspacesById: Record<string, Workspace> = {};
+
+    for (const workspace of [...sourceWorkspaces, ...targetWorkspaces]) {
+      allWorkspacesById[workspace.id] = workspace;
+    }
+
+    return allWorkspacesById;
+  },
+);
+
 export const missingTargetWorkspacesSelector = createSelector(
   includedSourceWorkspacesSelector,
   (includedSourceWorkspaces): Workspace[] =>

--- a/src/redux/workspaces/workspacesSelectors.ts
+++ b/src/redux/workspaces/workspacesSelectors.ts
@@ -74,17 +74,19 @@ export const targetWorkspacesSelector = createSelector(
   },
 );
 
-export const allWorkspacesByIdSelector = createSelector(
+export const allFreeWorkspaceIdsSelector = createSelector(
   sourceWorkspacesSelector,
   targetWorkspacesSelector,
-  (sourceWorkspaces, targetWorkspaces): Record<string, Workspace> => {
-    const allWorkspacesById: Record<string, Workspace> = {};
+  (sourceWorkspaces, targetWorkspaces): string[] => {
+    const allFreeWorkspaceIds: string[] = [];
 
     for (const workspace of [...sourceWorkspaces, ...targetWorkspaces]) {
-      allWorkspacesById[workspace.id] = workspace;
+      if (!workspace.isPaid) {
+        allFreeWorkspaceIds.push(workspace.id);
+      }
     }
 
-    return allWorkspacesById;
+    return allFreeWorkspaceIds;
   },
 );
 


### PR DESCRIPTION
## Description

Adds check to prevent fetching tasks for free Toggl accounts. Tasks are a paid-only feature in Toggl.

## Overview of Changes

- Prevent `402` errors from Toggl when trying to access tasks from a free workspace
- Add `ApiError` class to get error details from failed `fetch` requests
